### PR TITLE
Enable ssl on api if api_ssl.

### DIFF
--- a/nchp/templates/nginx.conf
+++ b/nchp/templates/nginx.conf
@@ -130,7 +130,7 @@ http {
     # This is the API server, which only JupyterHub talks to.
     # This is protected by requiring an Authentication header.
     server {
-        listen {{api_ip}}:{{api_port}} {% if public_ssl %}ssl{% endif %};
+        listen {{api_ip}}:{{api_port}} {% if api_ssl %}ssl{% endif %};
 
         {% if api_ssl %}
         ssl_protocols TLSv1.2;


### PR DESCRIPTION
Without this, I get `no "ssl_certificate" is defined in server listening on SSL port while SSL handshaking` on api port. I haven't actually enabled ssl on the api port.
