### PR TITLE
Make client_max_body_size tunable

### DIFF
--- a/nchp/app.py
+++ b/nchp/app.py
@@ -147,6 +147,13 @@ class NCHPApp(Application):
         help='Target to route to on error. NOT IMPLEMENTED YET'
     )
 
+    # performance tuning!
+    client_max_body_size = Unicode(
+        '256M',
+        help='Maximum size of client uploads. This limits notebook sizes. Accepts common byte suffixes (M/k/G). Set 0 to disable limit',
+        config=True
+    )
+
     def initialize(self, argv=None):
         self.parse_command_line(argv)
 
@@ -217,7 +224,8 @@ class NCHPApp(Application):
             'api_ssl_ciphers': self.api_ssl_ciphers,
             'api_ssl_dhparam': self.api_ssl_dhparam,
             'error_path': self.error_path,
-            'error_target': self.error_target
+            'error_target': self.error_target,
+            'client_max_body_size': self.client_max_body_size
         }
         return template.render(**context)
 

--- a/nchp/templates/nginx.conf
+++ b/nchp/templates/nginx.conf
@@ -103,7 +103,7 @@ http {
 
         # Set a high client body size by default
         # You will probably run into other timeouts before that
-        client_max_body_size 256M;
+        client_max_body_size {{ client_max_body_size }};
         location / {
             # We use lua code to determine which backend this URL will go
             # to. It checks the route table (maintained by the api server{}

--- a/nchp/templates/nginx.conf
+++ b/nchp/templates/nginx.conf
@@ -8,9 +8,14 @@ worker_processes auto;
 daemon off;
 
 # Set number of connections accepted per worker
+# We set worker_processes to auto, so total number of connections is
+# 1024 * number of cores on the machine
 events {
-    worker_connections 768;
+    worker_connections 1024;
 }
+
+# 2x of worker_connections, since a connection uses up 2 fds
+worker_rlimit_nofile 2048;
 
 # This needs to be in 'main' since otherwise nginx
 # will try to write to /var/log/nginx/error.log and failed

--- a/nchp/templates/nginx.conf
+++ b/nchp/templates/nginx.conf
@@ -96,6 +96,9 @@ http {
         ssl_certificate_key {{ public_ssl_key }};
         {% endif %}
 
+        # Set a high client body size by default
+        # You will probably run into other timeouts before that
+        client_max_body_size 256M;
         location / {
             # We use lua code to determine which backend this URL will go
             # to. It checks the route table (maintained by the api server{}


### PR DESCRIPTION
The default 1m is too small for notebooks.
