### PR TITLE
adding /health endpoint that always returns 200

### DIFF
--- a/nchp/templates/nginx.conf
+++ b/nchp/templates/nginx.conf
@@ -117,7 +117,6 @@ http {
         
         location = /healthz {
           return 200;
-          #access_log off;
         }
 
         location / {

--- a/nchp/templates/nginx.conf
+++ b/nchp/templates/nginx.conf
@@ -114,6 +114,11 @@ http {
         {% endif %}
 
         client_max_body_size {{ client_max_body_size }};
+        
+        location = /healthz {
+          return 200;
+          #access_log off;
+        }
 
         location / {
             # We use lua code to determine which backend this URL will go


### PR DESCRIPTION
In order to use the Ingress type an to the service endpoint must be available to that will return HTTP 200. `/` returns 302 to a simple get, as it should. I added `/healthz` which will always return 200,  mimicking the kubernetes default endpoint health check.